### PR TITLE
Statpost suppression

### DIFF
--- a/asterisk/configs/rpt.conf.sample
+++ b/asterisk/configs/rpt.conf.sample
@@ -181,7 +181,7 @@ startup_macro =
 ; ** For ACID and Debian ***
 ;statpost_program = /usr/bin/wget,-q,--timeout=15,--tries=1,--output-document=/dev/null                       
 ;statpost_url = http://stats.allstarlink.org/uhandler.php ; Status updates 
-;force_statpost = 0
+;force_statpost = 0 ; only use this if you have a very good reason to register nodes below 2000
 
 ; ** For Limey Linux **
 ;statpost_program = /bin/wget,-q,--timeout=15,--tries=1,--output-document=/dev/null                       

--- a/asterisk/configs/rpt.conf.sample
+++ b/asterisk/configs/rpt.conf.sample
@@ -181,6 +181,7 @@ startup_macro =
 ; ** For ACID and Debian ***
 ;statpost_program = /usr/bin/wget,-q,--timeout=15,--tries=1,--output-document=/dev/null                       
 ;statpost_url = http://stats.allstarlink.org/uhandler.php ; Status updates 
+;force_statpost = 0
 
 ; ** For Limey Linux **
 ;statpost_program = /bin/wget,-q,--timeout=15,--tries=1,--output-document=/dev/null                       


### PR DESCRIPTION
This change suppresses statistics posting for node numbers less than 2000 (unless overridden.)  This will help to reduce unnecessary statistics posting traffic.